### PR TITLE
Add usability improvements to disable tabPanels that are not runnable…

### DIFF
--- a/server-diffExpress.R
+++ b/server-diffExpress.R
@@ -1,5 +1,5 @@
-
-
+library(DESeq2)
+library(MAST)
 
 observe({
   

--- a/server-initInputData.R
+++ b/server-initInputData.R
@@ -123,7 +123,10 @@ reactiveSeuratObject <- eventReactive(input$upload_data,
                                      #names.delim = "\\-", names.field = 2
                                      shiny::setProgress(value = 0.8, detail = "Done.")
                                      print(ngsData)
-                                     output$nextStep1 <- renderText({"Next step: QC & Filter"})
+                                     ## output$nextStep1 <- renderText({"Next step: QC & Filter"})
+                                     output$nextStep1 <- renderUI({
+                                         actionButton("done_input_data", "Next step: QC & Filter")
+                                     })
                                      return(list("ngsData"=ngsData))
                                    })
                                  }

--- a/server-qcfilter.R
+++ b/server-qcfilter.R
@@ -1,3 +1,5 @@
+library(scater)
+
 observe({
   ThresholdDataReactive()
   if (!is.null(reactiveSeuratObject()$ngsData)){

--- a/server-sc3Clustering.R
+++ b/server-sc3Clustering.R
@@ -1,3 +1,4 @@
+library(SC3)
 
 observe({
   

--- a/ui-tab-inputdata.R
+++ b/ui-tab-inputdata.R
@@ -34,7 +34,7 @@ tabItem(tabName = "datainput",
                                #)
               ), # ConditionalPanel
               hr(),
-              textOutput("nextStep1")
+              uiOutput("nextStep1")
               
 
             ), # sidebarPanel


### PR DESCRIPTION
… in order to facilitate consistency. Minor performance changes (see below).

- [usability improvement] Include `shinyjs`-based inactiveLinks for steps that re not yet runnable due to lack of upstream-dependant steps. Kept only the `ui-tab-intro.R` and `ui-tab-saveObject.R` enabled by default, as they are the only ones that input data.

: Still, might it make sense to split the save/load seurat object steps from ui-tab-saveObject.R to the `ui-tab-inputdata.R`, so the flow is kept? Also, what do you think about moving the save capabilities to the very last step, e.g. after sc3 clustering?

: Also, please note I bulk-enabled several tabSets when the user clicks the `input$clusteringSelect`, since, to my understanding, many things can be done at this step (diff expression, save the object, or run sc3 clustering).

- [possible usability improvement] Replace the textOutput named `nextStep1` to a goButton that indeed changes the tabPanel directly

: Only added the capability here because I'm not sure you agree with that, but I could extend it to (most) steps, what do you think?

- [performance] Move `library` calls to their specific server steps, so they're not loaded from the very beginning (not sure this is working as expected)

- [performance] Add `supressPackagesStartupMessages` to the library load steps in `app.R` to put logs on a diet